### PR TITLE
Update NavigationViewControllerDelegate method implementations

### DIFF
--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -5,7 +5,7 @@ import MapboxDirections
 import Mapbox
 
 
-class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, VoiceControllerDelegate, NavigationMapViewDelegate, NavigationViewControllerDelegate {
+class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate {
     
     var mapView: NavigationMapView?
     var currentRoute: Route? {
@@ -75,7 +75,7 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
     @objc func tappedButton(sender: UIButton) {
         guard let route = currentRoute else { return }
         let navigationViewController = NavigationViewController(for: route)
-        navigationViewController.delegate = self
+        navigationViewController.delegate = self as? NavigationViewControllerDelegate
         
         // This allows the developer to simulate the route.
         // Note: If copying and pasting this code in your own project,
@@ -111,8 +111,9 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
             self.mapView?.showWaypoints(self.currentRoute!)
         }
     }
-    
-    // Delegate method called when the user selects a route
+}
+
+extension AdvancedViewController: NavigationMapViewDelegate {
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
         self.currentRoute = route
     }

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -75,6 +75,7 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
     @objc func tappedButton(sender: UIButton) {
         guard let route = currentRoute else { return }
         let navigationViewController = NavigationViewController(for: route)
+        navigationViewController.delegate = self as? NavigationViewControllerDelegate
         
         // This allows the developer to simulate the route.
         // Note: If copying and pasting this code in your own project,

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -75,7 +75,6 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
     @objc func tappedButton(sender: UIButton) {
         guard let route = currentRoute else { return }
         let navigationViewController = NavigationViewController(for: route)
-        navigationViewController.delegate = self as? NavigationViewControllerDelegate
         
         // This allows the developer to simulate the route.
         // Note: If copying and pasting this code in your own project,

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -5,7 +5,7 @@ import MapboxDirections
 import Mapbox
 
 
-class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate {
+class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, NavigationMapViewDelegate, NavigationViewControllerDelegate {
     
     var mapView: NavigationMapView?
     var currentRoute: Route? {
@@ -75,7 +75,7 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
     @objc func tappedButton(sender: UIButton) {
         guard let route = currentRoute else { return }
         let navigationViewController = NavigationViewController(for: route)
-        navigationViewController.delegate = self as? NavigationViewControllerDelegate
+        navigationViewController.delegate = self
         
         // This allows the developer to simulate the route.
         // Note: If copying and pasting this code in your own project,
@@ -111,9 +111,8 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
             self.mapView?.showWaypoints(self.currentRoute!)
         }
     }
-}
-
-extension AdvancedViewController: NavigationMapViewDelegate {
+    
+    // Delegate method called when the user selects a route
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
         self.currentRoute = route
     }

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -4,7 +4,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class CustomDestinationMarkerController: UIViewController, NavigationViewControllerDelegate {
+class CustomDestinationMarkerController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -31,9 +31,11 @@ class CustomDestinationMarkerController: UIViewController, NavigationViewControl
             self.present(navigationController, animated: true, completion: nil)
         }
     }
-    
-    func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
-        var annotationImage = mapView.dequeueReusableAnnotationImage(withIdentifier: "marker")
+}
+
+extension CustomDestinationMarkerController: NavigationViewControllerDelegate {
+    func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        var annotationImage = navigationViewController.mapView!.dequeueReusableAnnotationImage(withIdentifier: "marker")
         
         if annotationImage == nil {
             // Leaning Tower of Pisa by Stefan Spieler from the Noun Project.
@@ -55,4 +57,3 @@ class CustomDestinationMarkerController: UIViewController, NavigationViewControl
         return annotationImage
     }
 }
-

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -4,7 +4,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class CustomServerViewController: UIViewController, NavigationViewControllerDelegate {
+class CustomServerViewController: UIViewController {
     
     let routeOptions = NavigationRouteOptions(coordinates: [
         CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648),
@@ -35,7 +35,9 @@ class CustomServerViewController: UIViewController, NavigationViewControllerDele
             self.present(self.navigationViewController!, animated: true, completion: nil)
         }
     }
-    
+}
+
+extension CustomServerViewController: NavigationViewControllerDelegate {
     // Never reroute internally. Instead,
     // 1. Fetch a route from your server
     // 2. Map Match the coordinates from your server
@@ -72,4 +74,3 @@ class CustomServerViewController: UIViewController, NavigationViewControllerDele
         return true
     }
 }
-

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -3,7 +3,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class EmbeddedExampleViewController: UIViewController, NavigationViewControllerDelegate  {
+class EmbeddedExampleViewController: UIViewController {
  
     @IBOutlet weak var reroutedLabel: UILabel!
     @IBOutlet weak var enableReroutes: UISwitch!
@@ -71,11 +71,10 @@ class EmbeddedExampleViewController: UIViewController, NavigationViewControllerD
             ])
         self.didMove(toParentViewController: self)
     }
+}
 
-    //MARK: - NavigationViewControllerDelegate
-    
+extension EmbeddedExampleViewController: NavigationViewControllerDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldRerouteFrom location: CLLocation) -> Bool {
         return enableReroutes.isOn
     }
 }
-

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -4,7 +4,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class WaypointArrivalScreenViewController: UIViewController, NavigationViewControllerDelegate {
+class WaypointArrivalScreenViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,7 +34,9 @@ class WaypointArrivalScreenViewController: UIViewController, NavigationViewContr
             self.present(navigationController, animated: true, completion: nil)
         }
     }
-    
+}
+
+extension WaypointArrivalScreenViewController: NavigationViewControllerDelegate {
     // Show an alert when arriving at the waypoint and wait until the user to start next leg.
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool {
         let alert = UIAlertController(title: "Arrived at \(String(describing: waypoint.name))", message: "Would you like to continue?", preferredStyle: .alert)

--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,6 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'Navigation-Examples' do
-  pod 'MapboxCoreNavigation', '~> 0.16'
-  pod 'MapboxNavigation', '~> 0.16'
+    pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :branch => '1ec5-delegate-rename-1376'
+    pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :branch => '1ec5-delegate-rename-1376'
 end

--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,6 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'Navigation-Examples' do
-    pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :branch => '1ec5-delegate-rename-1376'
-    pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :branch => '1ec5-delegate-rename-1376'
+    pod 'MapboxCoreNavigation', '~> 0.17'
+    pod 'MapboxNavigation', '~> 0.17'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Mapbox-iOS-SDK (4.0.0)
-  - MapboxCoreNavigation (0.17.0-beta.1):
+  - Mapbox-iOS-SDK (4.0.1)
+  - MapboxCoreNavigation (0.17.0):
     - MapboxDirections.swift (~> 0.20.0)
     - MapboxMobileEvents (~> 0.4)
     - Turf (~> 0.1)
   - MapboxDirections.swift (0.20.0):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.4.0)
-  - MapboxNavigation (0.17.0-beta.1):
+  - MapboxNavigation (0.17.0):
     - Mapbox-iOS-SDK (~> 4.0)
-    - MapboxCoreNavigation (= 0.17.0-beta.1)
+    - MapboxCoreNavigation (= 0.17.0)
     - MapboxSpeech (~> 0.0.1)
     - Solar (~> 2.1)
   - MapboxSpeech (0.0.1)
@@ -18,46 +18,32 @@ PODS:
   - Turf (0.1.1)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, branch `1ec5-delegate-rename-1376`)
-  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, branch `1ec5-delegate-rename-1376`)
+  - MapboxCoreNavigation (~> 0.17)
+  - MapboxNavigation (~> 0.17)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Mapbox-iOS-SDK
+    - MapboxCoreNavigation
     - MapboxDirections.swift
     - MapboxMobileEvents
+    - MapboxNavigation
     - MapboxSpeech
     - Polyline
     - Solar
     - Turf
 
-EXTERNAL SOURCES:
-  MapboxCoreNavigation:
-    :branch: 1ec5-delegate-rename-1376
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-  MapboxNavigation:
-    :branch: 1ec5-delegate-rename-1376
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-
-CHECKOUT OPTIONS:
-  MapboxCoreNavigation:
-    :commit: f6a67522cd456dddc458852c0787060a1dcd17b5
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-  MapboxNavigation:
-    :commit: f6a67522cd456dddc458852c0787060a1dcd17b5
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 271754e96eb4434ba1b0a8c68432e1ea26fe9841
-  MapboxCoreNavigation: 2f84ea58a6dd555b278994c750981e32ed4cb2a9
+  Mapbox-iOS-SDK: 09b978be732d753e5c5e2911460fc0a018ce9be6
+  MapboxCoreNavigation: 729666a164ceacb789b63047406a5c95ca965bbd
   MapboxDirections.swift: 9a46ca0f0608c76393f392ae793459cc30aa846f
   MapboxMobileEvents: e71cf788a95fa0c01ad6ce17fd5efd13140af5ff
-  MapboxNavigation: d75ec22bfdf6946bf8f791e941cfeccd5c745945
+  MapboxNavigation: afe18c9de475aefc1387100daa3a46cc8f95a5de
   MapboxSpeech: 6cc9b3d53adc2988af3ebc704dd17907b84a3f9f
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: 4ace207379c8d58a8e45842755de821dac3fae72
 
-PODFILE CHECKSUM: 42b3239295bad33d8034717a74644c149b67eca4
+PODFILE CHECKSUM: 0e280dc47e584e46c7e9687bffb8dff53ec243dc
 
 COCOAPODS: 1.5.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,50 +1,63 @@
 PODS:
-  - Mapbox-iOS-SDK (3.7.6)
-  - MapboxCoreNavigation (0.16.0):
-    - MapboxDirections.swift (~> 0.19.0)
-    - MapboxMobileEvents (~> 0.3)
-    - Turf (~> 0.0.4)
-  - MapboxDirections.swift (0.19.1):
+  - Mapbox-iOS-SDK (4.0.0)
+  - MapboxCoreNavigation (0.17.0-beta.1):
+    - MapboxDirections.swift (~> 0.20.0)
+    - MapboxMobileEvents (~> 0.4)
+    - Turf (~> 0.1)
+  - MapboxDirections.swift (0.20.0):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.4.0)
-  - MapboxNavigation (0.16.0):
-    - Mapbox-iOS-SDK (~> 3.6)
-    - MapboxCoreNavigation (= 0.16.0)
+  - MapboxNavigation (0.17.0-beta.1):
+    - Mapbox-iOS-SDK (~> 4.0)
+    - MapboxCoreNavigation (= 0.17.0-beta.1)
     - MapboxSpeech (~> 0.0.1)
     - Solar (~> 2.1)
-    - Turf (~> 0.0.4)
   - MapboxSpeech (0.0.1)
   - Polyline (4.2.0)
   - Solar (2.1.0)
-  - Turf (0.0.4)
+  - Turf (0.1.1)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (~> 0.16)
-  - MapboxNavigation (~> 0.16)
+  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, branch `1ec5-delegate-rename-1376`)
+  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, branch `1ec5-delegate-rename-1376`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Mapbox-iOS-SDK
-    - MapboxCoreNavigation
     - MapboxDirections.swift
     - MapboxMobileEvents
-    - MapboxNavigation
     - MapboxSpeech
     - Polyline
     - Solar
     - Turf
 
+EXTERNAL SOURCES:
+  MapboxCoreNavigation:
+    :branch: 1ec5-delegate-rename-1376
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+  MapboxNavigation:
+    :branch: 1ec5-delegate-rename-1376
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+
+CHECKOUT OPTIONS:
+  MapboxCoreNavigation:
+    :commit: f6a67522cd456dddc458852c0787060a1dcd17b5
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+  MapboxNavigation:
+    :commit: f6a67522cd456dddc458852c0787060a1dcd17b5
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 23ececda1d90c3b436b45e2c88e9677f025303c0
-  MapboxCoreNavigation: 0ebb72a3253af35695f2b2bd7c919d67ad354fb5
-  MapboxDirections.swift: 3d902e3dc35f14cc6a322785e07f2ee6197237dc
+  Mapbox-iOS-SDK: 271754e96eb4434ba1b0a8c68432e1ea26fe9841
+  MapboxCoreNavigation: 2f84ea58a6dd555b278994c750981e32ed4cb2a9
+  MapboxDirections.swift: 9a46ca0f0608c76393f392ae793459cc30aa846f
   MapboxMobileEvents: e71cf788a95fa0c01ad6ce17fd5efd13140af5ff
-  MapboxNavigation: 6fc118df531264d75f6b22b459ed9271a941b0b7
+  MapboxNavigation: d75ec22bfdf6946bf8f791e941cfeccd5c745945
   MapboxSpeech: 6cc9b3d53adc2988af3ebc704dd17907b84a3f9f
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
-  Turf: 6c169618fa671e3f8a7b764b5b3332053ad6110e
+  Turf: 4ace207379c8d58a8e45842755de821dac3fae72
 
-PODFILE CHECKSUM: 46a8d1d7c5b8ea08581226b0736f6a4cec17d5ba
+PODFILE CHECKSUM: 42b3239295bad33d8034717a74644c149b67eca4
 
 COCOAPODS: 1.5.0


### PR DESCRIPTION
mapbox/mapbox-navigation-ios#1413 renames a number of NavigationViewControllerDelegate methods. This PR renames one method as a result. It also splits out delegate method implementations into extensions, which is a common practice in Swift for keeping classes tidy.

These changes, or at least 275bcdf3177b02f7d9aa713c40b36c78243ef092, need to be brought into the navigation SDK repository after mapbox/mapbox-navigation-ios#1413 lands but before we release mapbox/mapbox-navigation-ios#1412.

/cc @bsudekum