### PR TITLE
Fix route simulation

### DIFF
--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -74,15 +74,11 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
     
     @objc func tappedButton(sender: UIButton) {
         guard let route = currentRoute else { return }
-        let navigationViewController = NavigationViewController(for: route)
-        navigationViewController.delegate = self
+        // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+        let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
         
-        // This allows the developer to simulate the route.
-        // Note: If copying and pasting this code in your own project,
-        // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-        if simulationIsEnabled {
-            navigationViewController.routeController.locationManager = SimulatedLocationManager(route: route)
-        }
+        let navigationViewController = NavigationViewController(for: route, locationManager: locationManager)
+        navigationViewController.delegate = self
         
         present(navigationViewController, animated: true, completion: nil)
     }

--- a/Navigation-Examples/Examples/Basic.swift
+++ b/Navigation-Examples/Examples/Basic.swift
@@ -18,14 +18,10 @@ class BasicViewController: UIViewController {
                 return
             }
             
-            let navigationController = NavigationViewController(for: route)
+            // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+            let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
             
-            // This allows the developer to simulate the route.
-            // Note: If copying and pasting this code in your own project,
-            // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-            if simulationIsEnabled {
-                navigationController.routeController.locationManager = SimulatedLocationManager(route: route)
-            }
+            let navigationController = NavigationViewController(for: route, locationManager: locationManager)
             
             self.present(navigationController, animated: true, completion: nil)
         }

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -18,15 +18,11 @@ class CustomDestinationMarkerController: UIViewController {
                 return
             }
             
-            let navigationController = NavigationViewController(for: route)
-            navigationController.delegate = self
+            // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+            let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
             
-            // This allows the developer to simulate the route.
-            // Note: If copying and pasting this code in your own project,
-            // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-            if simulationIsEnabled {
-                navigationController.routeController.locationManager = SimulatedLocationManager(route: route)
-            }
+            let navigationController = NavigationViewController(for: route, locationManager: locationManager)
+            navigationController.delegate = self
             
             self.present(navigationController, animated: true, completion: nil)
         }

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -22,15 +22,11 @@ class CustomServerViewController: UIViewController {
                 return
             }
             
-            self.navigationViewController = NavigationViewController(for: route)
-            self.navigationViewController?.delegate = self
+            // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+            let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
             
-            // This allows the developer to simulate the route.
-            // Note: If copying and pasting this code in your own project,
-            // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-            if simulationIsEnabled {
-                self.navigationViewController?.routeController.locationManager = SimulatedLocationManager(route: route)
-            }
+            self.navigationViewController = NavigationViewController(for: route, locationManager: locationManager)
+            self.navigationViewController?.delegate = self
             
             self.present(self.navigationViewController!, animated: true, completion: nil)
         }

--- a/Navigation-Examples/Examples/Custom-Voice-Controller.swift
+++ b/Navigation-Examples/Examples/Custom-Voice-Controller.swift
@@ -24,15 +24,10 @@ class CustomVoiceControllerUI: UIViewController {
                 return
             }
             
-            let navigationController = NavigationViewController(for: route)
-            navigationController.voiceController = self.voiceController
+            // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+            let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
             
-            // This allows the developer to simulate the route.
-            // Note: If copying and pasting this code in your own project,
-            // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-            if simulationIsEnabled {
-                navigationController.routeController.locationManager = SimulatedLocationManager(route: route)
-            }
+            let navigationController = NavigationViewController(for: route, locationManager: locationManager, voiceController: self.voiceController)
             
             self.present(navigationController, animated: true, completion: nil)
         }

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -50,14 +50,10 @@ class EmbeddedExampleViewController: UIViewController {
     }
     
     func startEmbeddedNavigation() {
-        let nav = NavigationViewController(for: route!)
+        // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+        let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route!) : nil
         
-        // This allows the developer to simulate the route.
-        // Note: If copying and pasting this code in your own project,
-        // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-        if simulationIsEnabled {
-            nav.routeController.locationManager = SimulatedLocationManager(route: route!)
-        }
+        let nav = NavigationViewController(for: route!, locationManager: locationManager)
         
         nav.delegate = self
         addChildViewController(nav)

--- a/Navigation-Examples/Examples/Styled-UI-Elements.swift
+++ b/Navigation-Examples/Examples/Styled-UI-Elements.swift
@@ -18,14 +18,10 @@ class CustomStyleUIElements: UIViewController {
                 return
             }
             
-            let navigationController = NavigationViewController(for: route, styles: [CustomDayStyle(), CustomNightStyle()])
+            // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+            let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
             
-            // This allows the developer to simulate the route.
-            // Note: If copying and pasting this code in your own project,
-            // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-            if simulationIsEnabled {
-                navigationController.routeController.locationManager = SimulatedLocationManager(route: route)
-            }
+            let navigationController = NavigationViewController(for: route, styles: [CustomDayStyle(), CustomNightStyle()], locationManager: locationManager)
             
             self.present(navigationController, animated: true, completion: nil)
         }

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -21,15 +21,11 @@ class WaypointArrivalScreenViewController: UIViewController {
                 return
             }
             
-            let navigationController = NavigationViewController(for: route)
-            navigationController.delegate = self
+            // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+            let locationManager = simulationIsEnabled ? SimulatedLocationManager(route: route) : nil
             
-            // This allows the developer to simulate the route.
-            // Note: If copying and pasting this code in your own project,
-            // comment out `simulationIsEnabled` as it is defined elsewhere in this project.
-            if simulationIsEnabled {
-                navigationController.routeController.locationManager = SimulatedLocationManager(route: route)
-            }
+            let navigationController = NavigationViewController(for: route, locationManager: locationManager)
+            navigationController.delegate = self
             
             self.present(navigationController, animated: true, completion: nil)
         }


### PR DESCRIPTION
Set the route and voice controllers when initializing the navigation view controller, following the backwards-incompatible changes in mapbox/mapbox-navigation-ios#1671.

/cc @JThramer @frederoni @akitchen