### PR TITLE
v0.23.0

### DIFF
--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -25,7 +25,7 @@ class CustomServerViewController: UIViewController {
             // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
             let navigationService = MapboxNavigationService(route: route, simulating: simulationIsEnabled ? .always : .onPoorGPS)
             
-            let navigationController = NavigationViewController(for: route, navigationService: navigationService)
+            self.navigationViewController = NavigationViewController(for: route, navigationService: navigationService)
             self.navigationViewController?.delegate = self
             
             self.present(self.navigationViewController!, animated: true, completion: nil)

--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,5 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'Navigation-Examples' do
-    pod 'MapboxCoreNavigation', '~> 0.22'
-    pod 'MapboxNavigation', '~> 0.22'
+    pod 'MapboxNavigation', '~> 0.23'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,27 +1,26 @@
 PODS:
-  - Mapbox-iOS-SDK (4.4.1)
-  - MapboxCoreNavigation (0.22.1):
+  - Mapbox-iOS-SDK (4.5.0)
+  - MapboxCoreNavigation (0.23.0):
     - MapboxDirections.swift (~> 0.24.0)
-    - MapboxMobileEvents (~> 0.5)
-    - MapboxNavigationNative (~> 3.1)
-    - Turf (~> 0.2)
-  - MapboxDirections.swift (0.24.0):
+    - MapboxMobileEvents (~> 0.6.0)
+    - MapboxNavigationNative (~> 3.2.0)
+    - Turf (~> 0.2.0)
+  - MapboxDirections.swift (0.24.1):
     - Polyline (~> 4.2)
-  - MapboxMobileEvents (0.5.1)
-  - MapboxNavigation (0.22.1):
+  - MapboxMobileEvents (0.6.0)
+  - MapboxNavigation (0.23.0):
     - Mapbox-iOS-SDK (~> 4.3)
-    - MapboxCoreNavigation (= 0.22.1)
+    - MapboxCoreNavigation (= 0.23.0)
     - MapboxSpeech (~> 0.0.1)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (3.1.4)
+  - MapboxNavigationNative (3.2.0)
   - MapboxSpeech (0.0.2)
   - Polyline (4.2.0)
   - Solar (2.1.0)
   - Turf (0.2.1)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (~> 0.22)
-  - MapboxNavigation (~> 0.22)
+  - MapboxNavigation (~> 0.23)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -37,17 +36,17 @@ SPEC REPOS:
     - Turf
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: e6a4f236c77f914ca2e19b929c6cc6b077ba1c4c
-  MapboxCoreNavigation: 5ee46b9c2c24c72d42719c109c6ee896b5c0b025
-  MapboxDirections.swift: 8f1dd1aedc13aeb226b9038eb73f08dcccbac0cd
-  MapboxMobileEvents: bacf6e176d65b4f3cc5280677183856a81216117
-  MapboxNavigation: 2ba9c5f5ef4832a90fd6d236415a6e7cc0716c4e
-  MapboxNavigationNative: 2e4314439ecc07268d76d9d1319225335b96834b
+  Mapbox-iOS-SDK: fb9dde66106a8f10d351f9697ac198049c8e5511
+  MapboxCoreNavigation: d96109ec7d3e17000a7eaf2b4133aa33ffb9da3d
+  MapboxDirections.swift: 25ea07ca06a3c64c335dc8852f3c94fcabd443c8
+  MapboxMobileEvents: 0218869f556a7fdac9f869e2f9c10e8c6dd7eed5
+  MapboxNavigation: 63b731f73b44ab0b727410e2a4e57a2f20cc184b
+  MapboxNavigationNative: 1173dc73d6643e321065cfaa55d253f67b55ab12
   MapboxSpeech: 9d46bca4d7e96318ec8d6ce93a1153ebaef319ba
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: 9763a5a2d7da05dfdd5ed56aeb0414b291b0fee1
 
-PODFILE CHECKSUM: 36158088128848b2d20848833b72f4c1c2b8a70c
+PODFILE CHECKSUM: 9c821eb9ff708a5808f3c8aa85f6a8adf03b05e5
 
 COCOAPODS: 1.6.0.beta.1


### PR DESCRIPTION
Upgraded to v0.23.0. Also fixed an issue where the bring-your-own-route example crashed on launch because of writing to a local variable but reading from an instance variable by a similar name.

/cc @JThramer