### PR TITLE
Fix custom route typo and warning

### DIFF
--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -25,7 +25,7 @@ class CustomServerViewController: UIViewController {
             // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
             let navigationService = MapboxNavigationService(route: route, simulating: simulationIsEnabled ? .always : .onPoorGPS)
             
-            let navigationController = NavigationViewController(for: route, navigationService: navigationService)
+            self.navigationViewController = NavigationViewController(for: route, navigationService: navigationService)
             self.navigationViewController?.delegate = self
             
             self.present(self.navigationViewController!, animated: true, completion: nil)


### PR DESCRIPTION
Fixed an issue where the bring-your-own-route example crashed on launch because of writing to a local variable but reading from an instance variable by a similar name.

Supersedes #31.

/cc @JThramer @vincethecoder