### PR TITLE
v0.31.0

### DIFF
--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -42,7 +42,7 @@ class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationMa
         mapView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView?.userTrackingMode = .follow
         mapView?.delegate = self
-        mapView?.navigationMapDelegate = self
+        mapView?.navigationMapViewDelegate = self
         
         let gesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
         mapView?.addGestureRecognizer(gesture)

--- a/Podfile
+++ b/Podfile
@@ -2,5 +2,5 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'Navigation-Examples' do
-    pod 'MapboxNavigation', '~> 0.30.0'
+    pod 'MapboxNavigation', '~> 0.31.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - Mapbox-iOS-SDK (4.9.0)
-  - MapboxCoreNavigation (0.30.0):
-    - MapboxDirections.swift (~> 0.27.0)
+  - MapboxCoreNavigation (0.31.0):
+    - MapboxDirections.swift (~> 0.27.3)
     - MapboxMobileEvents (~> 0.8.1)
-    - MapboxNavigationNative (~> 5.0.0)
+    - MapboxNavigationNative (~> 6.1.1)
     - Turf (~> 0.3.0)
-  - MapboxDirections.swift (0.27.2):
+  - MapboxDirections.swift (0.27.3):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.8.1)
-  - MapboxNavigation (0.30.0):
+  - MapboxNavigation (0.31.0):
     - Mapbox-iOS-SDK (~> 4.3)
-    - MapboxCoreNavigation (= 0.30.0)
+    - MapboxCoreNavigation (= 0.31.0)
     - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (5.0.0)
+  - MapboxNavigationNative (6.1.1)
   - MapboxSpeech (0.1.1)
   - Polyline (4.2.0)
   - Solar (2.1.0)
   - Turf (0.3.0)
 
 DEPENDENCIES:
-  - MapboxNavigation (~> 0.30.0)
+  - MapboxNavigation (~> 0.31.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -37,16 +37,16 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 225036950837cbe408e6b333e51cd6001c122499
-  MapboxCoreNavigation: f446c90e4324157e76a224c233e3daa2042f181e
-  MapboxDirections.swift: b67d0b0bd0ac46906642baba38f4be777c50d68e
+  MapboxCoreNavigation: 203f774086328766e5d084e02e3855b7459ea0dd
+  MapboxDirections.swift: af3d8bc8cd80ed6e498dd6ed933f3c348799e1e2
   MapboxMobileEvents: 0f30fe39687f26fd8f255335053023ba039a0392
-  MapboxNavigation: 785961459d7b59ee442a2a80b7b8bcfc88a9383b
-  MapboxNavigationNative: bb220f45f93123adae2c05dfb74080773af128f3
+  MapboxNavigation: 188a6e4652da8de68b2e19bf7928a40766e9f3eb
+  MapboxNavigationNative: 4b3c0d38c57f43ba525283dab6abdead0558b2bc
   MapboxSpeech: 59b3984d3f433a443d24acf53097f918c5cc70f9
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: c6bdf62d6a70c647874f295dd1cf4eefc0c3e9e6
 
-PODFILE CHECKSUM: c7d42dfddaef5c324a9b04721929d8bf3fe82524
+PODFILE CHECKSUM: 503e37c96cf7f75e2b65b4ece20b10a2e1457636
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
Upgraded to navigation SDK v0.31.0, resolving one deprecation warning in the process.

/cc @mapbox/navigation-ios