### PR TITLE
Relinquish rights to code herein

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,5 @@
+To the extent possible under law, Mapbox has waived all copyright and related or neighboring rights to Mapbox Navigation SDK Examples. This work is published from the United States.
+
+CC0 1.0 Universal (CC0 1.0)
+Public Domain Dedication
+https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Dedicate this repository to the public domain via CC0: shorter than the WTFPL and sweeter than `HKQuantityTypeIdentifier.dietarySugar`.

(Much of the code in this repository was brought over from the ios-sdk-examples repository in #43. That repository was dedicated to the public domain in mapbox/ios-sdk-examples#63.)

/cc @mapbox/navigation-ios @kathleenlu09 @mapbox/docs