### PR TITLE
CircleCi support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,33 @@
-# For a detailed guide to building and testing on iOS, read the docs:
-# https://circleci.com/docs/2.0/testing-ios/
-
 version: 2.1
 
 jobs:
-  build:
-
+  build-job:
+    parameters:
+      xcode:
+        type: string
+        default: "11.4"
+      device:
+        type: string
+        default: "iPhone 8 Plus"
+      ios:
+        type: string
+        default: "13.4"
     macos:
-      xcode: 11.4.1
-
+      xcode: << parameters.xcode >>
     steps:
       - checkout
-      - run: pod install
+      - run:
+          name: Install Dependencies
+          command: pod install
+      - run:
+          name: Navigation-Examples
+          command: xcodebuild -workspace Navigation-Examples.xcworkspace -scheme Navigation-Examples -sdk iphonesimulator -configuration Release -destination "platform=iOS Simulator,name=<< parameters.device >>,OS=<< parameters.ios >>" clean build
 
-      # Collect XML test results data to show in the UI, and save the same XML
-      # files under test-results folder in the Artifacts tab
-      - store_test_results:
-          path: test_output
-      - store_artifacts:
-          path: test_output
-          destination: scan-output
+workflows:
+  workflow:
+    jobs:
+      - build-job:
+          name: "Xcode_11.5_iOS_13.5"
+          xcode: "11.5.0"
+          ios: "13.5"
+          device: "iPhone 11 Pro"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
       - run:
           name: Navigation-Examples
           command: xcodebuild -workspace Navigation-Examples.xcworkspace -scheme Navigation-Examples -sdk iphonesimulator -configuration Release -destination "platform=iOS Simulator,name=<< parameters.device >>,OS=<< parameters.ios >>" clean build
+      - run:
+          name: DocsCode
+          command: xcodebuild -workspace Navigation-Examples.xcworkspace -scheme DocsCode -sdk iphonesimulator -configuration Release -destination "platform=iOS Simulator,name=<< parameters.device >>,OS=<< parameters.ios >>" clean build
 
 workflows:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+# For a detailed guide to building and testing on iOS, read the docs:
+# https://circleci.com/docs/2.0/testing-ios/
+
+version: 2.1
+
+jobs:
+  build:
+
+    macos:
+      xcode: 11.4.1
+
+    steps:
+      - checkout
+      - run: pod install
+
+      # Collect XML test results data to show in the UI, and save the same XML
+      # files under test-results folder in the Artifacts tab
+      - store_test_results:
+          path: test_output
+      - store_artifacts:
+          path: test_output
+          destination: scan-output

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Mapbox Navigation SDK Examples
 
+[![CircleCI](https://circleci.com/gh/mapbox/navigation-ios-examples.svg?style=svg)](https://circleci.com/gh/mapbox/navigation-ios-examples)
+
 A collection of examples showing off the [Mapbox Navigation SDK](https://github.com/mapbox/mapbox-navigation-ios).
 
 ![](https://user-images.githubusercontent.com/1058624/34502971-fac695b4-efca-11e7-9eb1-426f38bd89bf.gif)


### PR DESCRIPTION
This change adds CircleCI support for navigation-ios-examples (#55). For now job fails because of compilation issues which were fixed in #54. Current jobs status can be found [here](https://app.circleci.com/pipelines/github/mapbox/navigation-ios-examples?branch=circleci-project-setup).