### PR TITLE
Replace deprecated method to correct one.

### DIFF
--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -35,8 +35,9 @@ class CustomDestinationMarkerController: UIViewController {
 }
 
 extension CustomDestinationMarkerController: MGLMapViewDelegate {
-    func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
-        var annotationImage = navigationViewController.mapView!.dequeueReusableAnnotationImage(withIdentifier: "marker")
+
+    func mapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        var annotationImage = mapView.dequeueReusableAnnotationImage(withIdentifier: "marker")
         
         if annotationImage == nil {
             // Leaning Tower of Pisa by Stefan Spieler from the Noun Project.


### PR DESCRIPTION
`func mapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?` delegate method should be used to successfully render custom image for annotation.

Closes #58.