### PR TITLE
Set CustomBottomBannerView's clipsToBounds to true

### DIFF
--- a/Navigation-Examples/Examples/CustomBars/CustomBottomBannerView.swift
+++ b/Navigation-Examples/Examples/CustomBars/CustomBottomBannerView.swift
@@ -39,7 +39,8 @@ class CustomBottomBannerView: UIView {
         addSubview(contentView)
         contentView.frame = bounds
         contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        
+
+        progressBar.clipsToBounds = true
         progressBar.progressTintColor = .systemGreen
         progressBar.layer.borderColor = UIColor.black.cgColor
         progressBar.layer.borderWidth = 2


### PR DESCRIPTION
This pull request is a very minor fix to hide the tint color of `CustomBottomBannerView`'s progress bar  that goes beyond the border.

Steps to replicate:
- Run the example.
- Select Custom Top & Bottom Bars.
- Tap Start Example.
- And check the progress bar just like on the screenshot(left image) below. (The image on the right is the fix)

|clipsToBounds not set|clipsToBounds set to true|
|-|-|
|<img width="240" src="https://user-images.githubusercontent.com/4591831/138568069-41aef5c6-74f7-424c-ac5b-b5ed7bb27fae.png" />|<img width="240" src="https://user-images.githubusercontent.com/4591831/138568074-93cf5a58-9eb9-45a9-a9ad-43b72d261890.png" />|
